### PR TITLE
Update link domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Godot Stairs
 
-This is an implementation of stair stepping based on [Shifty's Godot Character Movement Manifesto](https://markdownpastebin.com/?id=d9d61e67f9d64db2bd215f165b931449) and [Collision Response: How to Climb a Staircase Properly](https://thelowrooms.xyz/articledir/programming_stepclimbing.php).
+This is an implementation of stair stepping based on [Shifty's Godot Character Movement Manifesto](https://markdownpastebin.com/?id=d9d61e67f9d64db2bd215f165b931449) and [Collision Response: How to Climb a Staircase Properly](https://thelowrooms.com/articledir/programming_stepclimbing.php).
 
 [TrenchBroom](https://github.com/TrenchBroom/TrenchBroom) and [Qodot](https://github.com/QodotPlugin/qodot-plugin) are used for map building.
 


### PR DESCRIPTION
Linked site domain was changed to use .com instead of .xyz; the .xyz link no longer works