### PR TITLE
QoL improvements

### DIFF
--- a/Player/Player.gd
+++ b/Player/Player.gd
@@ -1,23 +1,19 @@
 extends CharacterBody3D
 
-@export_enum("Box", "Cylinder", "Capsule" ) var active_shape : String = "Box":
+@export_enum("Box", "Cylinder") var active_shape : String = "Box":
 	set(value):
 		active_shape = value
 		if not Engine.is_editor_hint():
 			init_hull()
 
-func init_hull():
-	%HullBox.disabled = true
-	%HullCylinder.disabled = true
-	%HullCapsule.disabled = true
-	
+func update_hull():
 	match active_shape:
 		"Box":
+			%HullCylinder.disabled = true
 			%HullBox.disabled = false
 		"Cylinder":
+			%HullBox.disabled = true
 			%HullCylinder.disabled = false
-		"Capsule":
-			%HullCapsule.disabled = false
 
 @onready var body = $Body
 @onready var head = $Body/Head
@@ -74,7 +70,7 @@ class StepResult:
 
 
 func _ready():
-	init_hull()
+	update_hull()
 	Input.set_mouse_mode(Input.MOUSE_MODE_CAPTURED)
 	
 	camera_target_position = camera.global_transform.origin

--- a/Player/Player.gd
+++ b/Player/Player.gd
@@ -1,5 +1,24 @@
 extends CharacterBody3D
 
+@export_enum("Box", "Cylinder", "Capsule" ) var active_shape : String = "Box":
+	set(value):
+		active_shape = value
+		if not Engine.is_editor_hint():
+			init_hull()
+
+func init_hull():
+	%HullBox.disabled = true
+	%HullCylinder.disabled = true
+	%HullCapsule.disabled = true
+	
+	match active_shape:
+		"Box":
+			%HullBox.disabled = false
+		"Cylinder":
+			%HullCylinder.disabled = false
+		"Capsule":
+			%HullCapsule.disabled = false
+
 @onready var body = $Body
 @onready var head = $Body/Head
 @onready var camera = $Body/Head/CameraMarker3D/Camera3D
@@ -55,6 +74,7 @@ class StepResult:
 
 
 func _ready():
+	init_hull()
 	Input.set_mouse_mode(Input.MOUSE_MODE_CAPTURED)
 	
 	camera_target_position = camera.global_transform.origin
@@ -101,6 +121,12 @@ func _input(event):
 		body.rotate_y(deg_to_rad(-event.relative.x * mouse_sensitivity))
 		head.rotate_x(deg_to_rad(-event.relative.y * mouse_sensitivity))
 		head.rotation.x = clamp(head.rotation.x, deg_to_rad(-89), deg_to_rad(89))
+	
+	if Input.is_action_just_pressed("ui_cancel"):
+		if Input.mouse_mode == Input.MOUSE_MODE_CAPTURED:
+			Input.set_mouse_mode(Input.MOUSE_MODE_VISIBLE)
+		elif Input.mouse_mode ==  Input.MOUSE_MODE_VISIBLE:
+			Input.set_mouse_mode(Input.MOUSE_MODE_CAPTURED)
 
 func _physics_process(delta):
 	update_camera = true

--- a/Player/Player.gd
+++ b/Player/Player.gd
@@ -9,11 +9,13 @@ extends CharacterBody3D
 func update_hull():
 	match active_shape:
 		"Box":
-			%HullCylinder.disabled = true
-			%HullBox.disabled = false
+			if hull_box and hull_cylinder:
+				hull_cylinder.disabled = true
+				hull_box.disabled = false
 		"Cylinder":
-			%HullBox.disabled = true
-			%HullCylinder.disabled = false
+			if hull_box and hull_cylinder:
+				hull_box.disabled = true
+				hull_cylinder.disabled = false
 
 @onready var body = $Body
 @onready var head = $Body/Head

--- a/Player/Player.gd
+++ b/Player/Player.gd
@@ -4,7 +4,7 @@ extends CharacterBody3D
 	set(value):
 		active_shape = value
 		if not Engine.is_editor_hint():
-			init_hull()
+			update_hull()
 
 func update_hull():
 	match active_shape:

--- a/Player/Player.gd
+++ b/Player/Player.gd
@@ -7,13 +7,12 @@ extends CharacterBody3D
 			update_hull()
 
 func update_hull():
-	match active_shape:
-		"Box":
-			if hull_box and hull_cylinder:
+	if hull_box and hull_cylinder:
+		match active_shape:
+			"Box":
 				hull_cylinder.disabled = true
 				hull_box.disabled = false
-		"Cylinder":
-			if hull_box and hull_cylinder:
+			"Cylinder":
 				hull_box.disabled = true
 				hull_cylinder.disabled = false
 

--- a/Player/Player.tscn
+++ b/Player/Player.tscn
@@ -25,16 +25,19 @@ wall_min_slide_angle = 0.0872665
 floor_snap_length = 0.2
 script = ExtResource("1")
 
-[node name="CollisionShape3D1" type="CollisionShape3D" parent="."]
+[node name="HullBox" type="CollisionShape3D" parent="."]
+unique_name_in_owner = true
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0)
 shape = SubResource("6")
 
-[node name="CollisionShape3D2" type="CollisionShape3D" parent="."]
+[node name="HullCylinder" type="CollisionShape3D" parent="."]
+unique_name_in_owner = true
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0)
 shape = SubResource("CylinderShape3D_juxiq")
 disabled = true
 
-[node name="CollisionShape3D3" type="CollisionShape3D" parent="."]
+[node name="HullCapsule" type="CollisionShape3D" parent="."]
+unique_name_in_owner = true
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0)
 shape = SubResource("CapsuleShape3D_sl4o1")
 disabled = true

--- a/Player/Player.tscn
+++ b/Player/Player.tscn
@@ -10,10 +10,6 @@ size = Vector3(0.6, 1.8, 0.6)
 height = 1.8
 radius = 0.3
 
-[sub_resource type="CapsuleShape3D" id="CapsuleShape3D_sl4o1"]
-radius = 0.3
-height = 1.8
-
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_sxnj7"]
 
 [sub_resource type="BoxMesh" id="BoxMesh_dhg0d"]
@@ -34,12 +30,6 @@ shape = SubResource("6")
 unique_name_in_owner = true
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0)
 shape = SubResource("CylinderShape3D_juxiq")
-disabled = true
-
-[node name="HullCapsule" type="CollisionShape3D" parent="."]
-unique_name_in_owner = true
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0)
-shape = SubResource("CapsuleShape3D_sl4o1")
 disabled = true
 
 [node name="Body" type="Node3D" parent="."]


### PR DESCRIPTION
NOTE: excuse for the commit mix

* changed CollisionShape node names

* added export active_shape to easily switch active shape in both editor and running project (avoids hassle of marking which are disabled and which not each time)

* added mouse capture toggle by pressing ESC_KEY

* removed Capsule shape (due lack of stepping functionality)

* fix: if active shape different from default one, no null instance error